### PR TITLE
Redirect for meat the brothers

### DIFF
--- a/meat
+++ b/meat
@@ -1,0 +1,5 @@
+<html>
+<script>
+window.location = "https://goo.gl/forms/DTFO3Cf4bSM4GS9F2";
+</script>
+</html>

--- a/meat
+++ b/meat
@@ -1,5 +1,15 @@
-<html>
-<script>
-window.location = "https://goo.gl/forms/DTFO3Cf4bSM4GS9F2";
-</script>
+<!DOCTYPE HTML>
+<html lang="en-US">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="refresh" content="0;url=https://goo.gl/forms/DTFO3Cf4bSM4GS9F2">
+        <script type="text/javascript">
+            window.location.href = "https://goo.gl/forms/DTFO3Cf4bSM4GS9F2"
+        </script>
+        <title>Meat the Brothers™</title>
+    </head>
+    <body>
+        <!-- Note: don't tell people to `click` the link, just tell them that it is a link. -->
+        If you are not redirected automatically, follow the <a href='https://goo.gl/forms/DTFO3Cf4bSM4GS9F2'></a>
+    </body>
 </html>


### PR DESCRIPTION
This pull request provides a redirect for the Meat the Brothers event. The event will be on October 27th and after the event, this page should be removed.

The redirect uses html, javascript and css. Using http and tls, users will be redirected to the google form for Meat the Brothers.